### PR TITLE
android amplitude tranking bug fix.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,23 @@
+apply plugin: 'com.android.library'
+
 buildscript {
     repositories {
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
-apply plugin: 'com.android.library'
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -28,5 +33,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.amplitude:android-sdk:2.9.2'
+    compile 'com.amplitude:android-sdk:2.14.1'
 }

--- a/android/src/main/java/com/radishmedia/RNAmplitudeHelper/ReactNativeAmplitudeHelper.java
+++ b/android/src/main/java/com/radishmedia/RNAmplitudeHelper/ReactNativeAmplitudeHelper.java
@@ -33,7 +33,7 @@ public class ReactNativeAmplitudeHelper extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void setup(String writeKey) {
-    Amplitude.getInstance().initialize(getCurrentActivity(), writeKey).enableForegroundTracking(this.mApplication).trackSessionEvents(true);
+    Amplitude.getInstance().initialize(getReactApplicationContext(), writeKey).enableForegroundTracking(this.mApplication).trackSessionEvents(true);
   }
 
   @ReactMethod


### PR DESCRIPTION
ReactNativeAmplitudeHelper에 초기 context가 누락되어 발생한 이슈로 해당 context를 정상적으로 변경하였고 개별 라이브러리로 관리되기때문에 해당 변경으로 인한 Side Effect은 없을것으로 예상됩니다. 그리고 android build 설정과 Amplitude SDK 버전이 낮아 현재 amplitude docs에서 추천하고 있는 버전으로 업데이트하였습니다.